### PR TITLE
Fix for lti2-gem location

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'activerecord-session_store', github: 'rails/activerecord-session_store'
 # gem 'oauth', path: '../oauth-sha256'
 
 # gem 'lti2', git: 'git@github.com:vitalsource/lti2-reference.git'
-gem 'lti2', path: '../LTI2-Reference'
+gem 'lti2', github: 'vitalsource/LTI2-Reference'
 
 gem 'activeadmin', github: 'gregbell/active_admin'
 #Active admin dependencies


### PR DESCRIPTION
Hi there,

we've updated the Gemfile to point to the github-repo (same as the LTI2_tc_sample_app TBH).
Thanks in advance for merging this PR!

Kind regards,
David
